### PR TITLE
module or domain: github board

### DIFF
--- a/.github/workflows/move-review-to-inprogress.yml
+++ b/.github/workflows/move-review-to-inprogress.yml
@@ -1,0 +1,18 @@
+name: Move from Review to In Progress
+
+on:
+  issues:
+    types:
+      - unlabeled
+
+jobs:
+  add-comment:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: dessant/label-actions@v3
+        with:
+          action-token: ${{ secrets.CERN_SIS_BOT_PAT }} 
+          project-url: https://github.com/orgs/cern-sis/projects/1
+          column-name: "In Progress" 
+          label-name: "ready-to-review" 
+


### PR DESCRIPTION
gh-actions: move task when unlabelled

* Add the possibility to move automatically an issue from the column Review to In Progress when the label ready-to-review is removed.